### PR TITLE
fixed closing of connection and cleaning endpoints

### DIFF
--- a/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
+++ b/src/main/java/io/strimzi/kafka/bridge/http/HttpBridge.java
@@ -137,15 +137,9 @@ public class HttpBridge extends AbstractVerticle {
 
     private void processConnection(HttpConnection httpConnection) {
         this.endpoints.put(httpConnection, new ConnectionEndpoint());
-        httpConnection.closeHandler(this::connectionCloseHandler);
-    }
-
-    private void connectionCloseHandler(Void v) {
-        log.info("connection closed");
-    }
-
-    private void connectionShutdownHandler(Void v) {
-
+        httpConnection.closeHandler(close ->{
+            closeConnectionEndpoint(httpConnection);
+        });
     }
 
     /**
@@ -164,7 +158,6 @@ public class HttpBridge extends AbstractVerticle {
             if (!endpoint.getSinks().isEmpty()) {
                 endpoint.getSinks().stream().forEach(sink -> sink.close());
             }
-            connection.close();
             this.endpoints.remove(connection);
         }
     }


### PR DESCRIPTION
Under normal flow the connection is closed by the client itself so we don't need ```connection.close()``` inside ```connection.closeHandler()```.